### PR TITLE
Update Ruby to 3.1.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1.3'
+          ruby-version: '3.1.4'
           bundler-cache: true
       - run: bundle exec danger
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
         ruby-version:
           - '2.7.5'
           - '3.0.5'
-          - '3.1.3'
+          - '3.1.4'
           - '3.2.2'
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Add Ruby 3.1.4 to test targets.

See https://www.ruby-lang.org/en/downloads/releases/ for Ruby release notes.

This pull request is created by [ workflow](https://github.com/manicmaniac/spaceship-slack2fa/blob/master/.github/workflows/update-ruby.yml).
