### PR TITLE
Update Ruby to 2.7.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - '2.7.5'
+          - '2.7.8'
           - '3.0.5'
           - '3.1.3'
           - '3.2.2'


### PR DESCRIPTION
Add Ruby 2.7.8 to test targets.

See https://www.ruby-lang.org/en/downloads/releases/ for Ruby release notes.

This pull request is created by [ workflow](https://github.com/manicmaniac/spaceship-slack2fa/blob/master/.github/workflows/update-ruby.yml).
