### PR TITLE
Update Ruby to 3.0.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         ruby-version:
           - '2.7.8'
-          - '3.0.6'
+          - '3.0.5'
           - '3.1.4'
           - '3.2.2'
     steps:


### PR DESCRIPTION
Add Ruby 3.0.5 to test targets.

See https://www.ruby-lang.org/en/downloads/releases/ for Ruby release notes.

This pull request is created by [ workflow](https://github.com/manicmaniac/spaceship-slack2fa/blob/master/.github/workflows/update-ruby.yml).
