### PR TITLE
Update Ruby to 3.1.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
         ruby-version:
           - '2.7.8'
           - '3.0.6'
-          - '3.1.4'
+          - '3.1.3'
           - '3.2.2'
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Add Ruby 3.1.3 to test targets.

See https://www.ruby-lang.org/en/downloads/releases/ for Ruby release notes.

This pull request is created by [ workflow](https://github.com/manicmaniac/spaceship-slack2fa/blob/master/.github/workflows/update-ruby.yml).
